### PR TITLE
fix: add name to devdocs-network in docker-compose.yml

### DIFF
--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -77,3 +77,4 @@ services:
 networks:
   devdocs-network:
     driver: bridge
+    name: devdocs-network


### PR DESCRIPTION
# Fix Docker Network Name for Consistent Inspection

## Issue

When attempting to inspect the Docker network using `docker network inspect devdocs-network`, the command failed because the actual network name created by Docker Compose was `devdocs_devdocs-network`.

## Root Cause

This discrepancy occurs because Docker Compose follows a standard naming convention for resources it creates: `[project name]_[resource name]`. In our original configuration, we defined the network as `devdocs-network`:

```yml
networks:
  devdocs-network:
    driver: bridge
```

However, Docker Compose automatically prefixed it with the project name, resulting in the actual network name being `devdocs_devdocs-network`.

## Solution

This PR explicitly sets the network name using the `name` property in the network definition:

```yml
networks:
  devdocs-network:
    driver: bridge
    name: devdocs-network  # Explicitly set the network name
```

With this change, the network will be created with exactly the name we expect, allowing `docker network inspect devdocs-network` to work as intended.